### PR TITLE
updated README and fixed broken test

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,25 @@ Productivity, Power and Performance.
 
 The Caerus Command Line Interface (CLI) makes it easy to initialise new projects and to generate scaffolding for existing projects. It’s an essential part of using Caerus.
 
+## Pre-requisite for running on Windows
+
+The commands that are executed require you to have access to a Bash shell. Assuming you have installed e.g. Git on your machine, the following command will configure your environment such that the Bash shell is used when executing the `caerus` commands:
+
+For x64 variants:
+
+
+`npm config set script-shell "c:\Program Files\Git\bin\bash.exe"`
+
+For x32 variants:
+
+`npm config set script-shell "c:\Program Files (x86)\Git\bin\bash.exe"`
+
+If you haven't got Git, but you have a Bash shell installed somewhere, replace the path above the with path to your local `bash.exe` file.
+
+If you want to revert this, for any reason, the following command should be executed:
+
+`npm config delete script-shell`
+
 ### Installing the Caerus CLI Tool
 
 Install the Caerus package from your workspace folder to get started:

--- a/src/tests/cli/generate.test.ts
+++ b/src/tests/cli/generate.test.ts
@@ -48,16 +48,16 @@ test('generating views', (done) => {
     done()
 
     // Check our view function name is correct
-    const newContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/new.tsx`, { encoding: 'utf8' })
+    const newContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/new.view.tsx`, { encoding: 'utf8' })
     expect(newContents).toMatch(/.*const NewTestView/)
 
-    const editContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/edit.tsx`, { encoding: 'utf8' })
+    const editContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/edit.view.tsx`, { encoding: 'utf8' })
     expect(editContents).toMatch(/.*const EditTestView/)
 
-    const showContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/show.tsx`, { encoding: 'utf8' })
+    const showContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/show.view.tsx`, { encoding: 'utf8' })
     expect(showContents).toMatch(/.*const ShowTestView/)
 
-    const indexContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/index.tsx`, { encoding: 'utf8' })
+    const indexContents = fs.readFileSync(`${process.cwd()}/client/src/views/test/index.view.tsx`, { encoding: 'utf8' })
     expect(indexContents).toMatch(/.*const IndexTestView/)
 
     const routeContents = fs.readFileSync(`${process.cwd()}/client/src/routes/test.routes.tsx`, { encoding: 'utf8' })


### PR DESCRIPTION
Have updated README file to show how to configure windows to use bash shell in order for the `test` and `caerus` script commands to work. Also fixed broken test which was looking for incorrect file locations in `src/tests/cli/generate.test.ts`